### PR TITLE
Revert "Added flatlist to tags"

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,8 +7,7 @@ import {
   StyleSheet,
   Image,
   TouchableOpacity,
-  ViewPropTypes,
-  FlatList
+  ViewPropTypes
 } from 'react-native';
 
 class Tags extends React.Component {
@@ -161,7 +160,7 @@ class Tags extends React.Component {
         {rightElement ? this.renderRightElement(rightElement, rightElementContainerStyle) : null}
       </View>
         {customElement ? customElement : null}
-      <FlatList style={StyleSheet.flatten([styles.tagsView, tagsViewStyle])}>
+      <View style={StyleSheet.flatten([styles.tagsView, tagsViewStyle])}>
         {tags.tagsArray.map((item, count) => {
             return (
               <View
@@ -180,7 +179,7 @@ class Tags extends React.Component {
             </View>
           )
           })}
-        </FlatList>
+        </View>
       </View>
   );
   }


### PR DESCRIPTION
If a FlatList exists, this library cannot be used in ScrollView.
Considering the versatility, it is better not to use FlatList.


This reverts commit 8e90feb8c06deddc7459eedf3e9f16deac45d9da.